### PR TITLE
api-reference: Tweak HEDLEY_ARRAY_PARAM docs

### DIFF
--- a/hedley/api-reference.html
+++ b/hedley/api-reference.html
@@ -164,7 +164,7 @@
 					<p>
 						Note that you can only reference parameters which
 						come <em>before</em> the array; in the example, if
-						the <code>n</code> and <code>elems</code> parameters were
+						the <code>y</code> and <code>elems</code> parameters were
 						reversed this would likely result in an error.
 					</p>
 


### PR DESCRIPTION
A trivial one-_character_ change, but I think a worthwhile one since the docs currently read:

> in the example, if the <code>n</code> and <code>elems</code> parameters were reversed

...But there's never been an <code>n</code> parameter in the `HEDLEY_ARRAY_PARAMS` example; the parameters are `x`, `y`, and `elems`.
